### PR TITLE
Filter subs by nodelist

### DIFF
--- a/pysensu/api.py
+++ b/pysensu/api.py
@@ -246,13 +246,16 @@ class SensuAPI(object):
         return True
 
     """
-    Subscriptions ops (non on the API)
+    Subscriptions ops (not directly in the Sensu API)
     """
-    def get_subscriptions(self):
+    def get_subscriptions(self, nodes=[]):
         """
-        Returns all the channels where nodes are subscribed
+        Returns all the channels where (optionally specified) nodes are subscribed
         """
-        data = self.get_clients()
+        if len(nodes) > 0:
+            data = [node for node in self.get_clients() if node['name'] in nodes]
+        else:
+            data = self.get_clients()
         channels = []
         for client in data:
             if 'subscriptions' in client:


### PR DESCRIPTION
A minor change which leaves the default behaviour as it is now, but allows the user to pass a list of clients for which subscriptions will be returned (as opposed to *all* clients)