### PR TITLE
changing import since __init__ is not a package

### DIFF
--- a/pysensu/api.py
+++ b/pysensu/api.py
@@ -3,7 +3,7 @@ import logging
 
 import requests
 from requests.auth import HTTPBasicAuth
-from __init__ import USER_AGENT
+from . import USER_AGENT
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
```
/usr/local/lib/python3.6/site-packages/pysensu/api.py in <module>()
      4 import requests
      5 from requests.auth import HTTPBasicAuth
----> 6 from __init__ import USER_AGENT
      7
      8 logger = logging.getLogger(__name__)

ImportError: cannot import name 'USER_AGENT'
```

`from pysensu.api import SensuAPI ` won't even work without this change, not sure how you've been running it. 