### PR TITLE
Fix status code check in case of error

### DIFF
--- a/pysensu/api.py
+++ b/pysensu/api.py
@@ -56,7 +56,7 @@ class SensuAPI(object):
             ))
             return resp
 
-        elif resp.status_code.startswith('400'):
+        elif resp.status_code == 400:
             logger.error('{}: {}'.format(
                 resp.status_code,
                 resp.text


### PR DESCRIPTION
If there is an error durring an API call and the server returns
something else than 200/201/202/204, it ends up calling startswith()
on a integer, which generates an exception:

Jul 19 13:45:26 hostname sh[25687]:     return sensu.get_clients()
Jul 19 13:45:26 hostname sh[25687]:   File "/usr/local/lib/python3.6/site-packages/pysensu/api.py", line 85, in get_clients
Jul 19 13:45:26 hostname sh[25687]:     result = self._request('GET', '/clients', data=json.dumps(data))
Jul 19 13:45:26 hostname sh[25687]:   File "/usr/local/lib/python3.6/site-packages/pysensu/api.py", line 59, in _request
Jul 19 13:45:26 hostname sh[25687]:     elif resp.status_code.startswith('400'):
Jul 19 13:45:26 hostname sh[25687]: AttributeError: 'int' object has no attribute 'startswith'

Fixes issue #9

I though I would propose something that is dead simple instead of the more complex PR #11 .
If PR #11 is accepted though, we can just abandon this PR.
